### PR TITLE
Add React admin UI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
-# Non-Sim Pricing API
+# Non-Sim Pricing API & UI
 
-A Node.js-based web service to support non-sim pricing flows, including:
-- Manual settlement
-- Player suspension
-- Direct CSV/MySQL ingestion
+This repository contains a simple Node.js API along with a standalone React
+frontend used for managing non-sim pricing flows.
 
-Designed for deployment via Render.com
+## Backend
+
+The Express API lives under `src/` and exposes a basic health check. Future
+iterations will handle settlement, player suspension and data ingestion.
+
+Run the API locally with:
+
+```bash
+npm start
+```
+
+## Frontend
+
+The React admin UI is located in `non-sim-pricing-ui/` and is scaffolded using
+Vite with Tailwind CSS. It currently works with dummy state only.
+
+To develop the UI (after installing dependencies):
+
+```bash
+cd non-sim-pricing-ui
+npm run dev
+```
+
+This will start the Vite dev server on port `5173`.
+
 

--- a/non-sim-pricing-ui/index.html
+++ b/non-sim-pricing-ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Non-Sim Pricing Admin</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/non-sim-pricing-ui/package.json
+++ b/non-sim-pricing-ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "non-sim-pricing-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.3.0"
+  }
+}

--- a/non-sim-pricing-ui/postcss.config.js
+++ b/non-sim-pricing-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/non-sim-pricing-ui/src/App.jsx
+++ b/non-sim-pricing-ui/src/App.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import FixtureSelector from './components/FixtureSelector'
+import SuspensionPanel from './components/SuspensionPanel'
+import SettlementTable from './components/SettlementTable'
+import SimControl from './components/SimControl'
+import CommitButton from './components/CommitButton'
+
+const dummyFixtures = [
+  { id: 1, name: 'Fixture 1' },
+  { id: 2, name: 'Fixture 2' },
+]
+
+const dummyPlayers = [
+  { id: 1, name: 'Player A', suspended: false, outcome: '' },
+  { id: 2, name: 'Player B', suspended: false, outcome: '' },
+]
+
+export default function App() {
+  const [selectedFixture, setSelectedFixture] = useState(dummyFixtures[0].id)
+  const [players, setPlayers] = useState(dummyPlayers)
+  const [useSim, setUseSim] = useState(false)
+
+  const toggleSuspension = (id) => {
+    setPlayers(players.map(p => p.id === id ? { ...p, suspended: !p.suspended } : p))
+  }
+
+  const updateOutcome = (id, outcome) => {
+    setPlayers(players.map(p => p.id === id ? { ...p, outcome } : p))
+  }
+
+  const handleCommit = () => {
+    console.log('Committing state:', { selectedFixture, players, useSim })
+  }
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Non-Sim Pricing Admin</h1>
+      <FixtureSelector fixtures={dummyFixtures} value={selectedFixture} onChange={setSelectedFixture} />
+      <SuspensionPanel players={players} onToggle={toggleSuspension} />
+      <SettlementTable players={players} onUpdate={updateOutcome} />
+      <SimControl value={useSim} onChange={setUseSim} />
+      <CommitButton onCommit={handleCommit} />
+    </div>
+  )
+}

--- a/non-sim-pricing-ui/src/components/CommitButton.jsx
+++ b/non-sim-pricing-ui/src/components/CommitButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function CommitButton({ onCommit }) {
+  return (
+    <button
+      className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+      onClick={onCommit}
+    >
+      Commit
+    </button>
+  )
+}

--- a/non-sim-pricing-ui/src/components/FixtureSelector.jsx
+++ b/non-sim-pricing-ui/src/components/FixtureSelector.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function FixtureSelector({ fixtures, value, onChange }) {
+  return (
+    <div>
+      <label className="block mb-1 font-medium">Select Fixture</label>
+      <select
+        className="border p-2 rounded w-full"
+        value={value}
+        onChange={e => onChange(Number(e.target.value))}
+      >
+        {fixtures.map(f => (
+          <option key={f.id} value={f.id}>{f.name}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/non-sim-pricing-ui/src/components/SettlementTable.jsx
+++ b/non-sim-pricing-ui/src/components/SettlementTable.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export default function SettlementTable({ players, onUpdate }) {
+  return (
+    <div>
+      <h2 className="font-medium mb-2">Settlement</h2>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-200 text-left">
+            <th className="p-2 border">Player</th>
+            <th className="p-2 border">Outcome</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map(p => (
+            <tr key={p.id} className="border-t">
+              <td className="p-2 border-r">{p.name}</td>
+              <td className="p-2">
+                <input
+                  className="border rounded p-1 w-full"
+                  value={p.outcome}
+                  onChange={e => onUpdate(p.id, e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/non-sim-pricing-ui/src/components/SimControl.jsx
+++ b/non-sim-pricing-ui/src/components/SimControl.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function SimControl({ value, onChange }) {
+  return (
+    <div className="flex items-center space-x-2">
+      <input
+        type="checkbox"
+        checked={value}
+        onChange={e => onChange(e.target.checked)}
+      />
+      <label>Use SIM when committing</label>
+    </div>
+  )
+}

--- a/non-sim-pricing-ui/src/components/SuspensionPanel.jsx
+++ b/non-sim-pricing-ui/src/components/SuspensionPanel.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export default function SuspensionPanel({ players, onToggle }) {
+  return (
+    <div>
+      <h2 className="font-medium mb-2">Suspension</h2>
+      <ul className="space-y-1">
+        {players.map(p => (
+          <li key={p.id} className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={p.suspended}
+              onChange={() => onToggle(p.id)}
+            />
+            <span>{p.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/non-sim-pricing-ui/src/index.css
+++ b/non-sim-pricing-ui/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/non-sim-pricing-ui/src/main.jsx
+++ b/non-sim-pricing-ui/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/non-sim-pricing-ui/tailwind.config.js
+++ b/non-sim-pricing-ui/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/non-sim-pricing-ui/vite.config.js
+++ b/non-sim-pricing-ui/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold React-based Non-Sim Pricing admin UI using Vite and Tailwind
- implement FixtureSelector, SuspensionPanel, SettlementTable, SimControl and CommitButton components
- show simple dummy state management in App
- update README with instructions for running the API and UI

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d0c7ae10083288937d5ee4ee59dca